### PR TITLE
Fix documentation errors

### DIFF
--- a/openapi/v2/papay/entrustweb.md
+++ b/openapi/v2/papay/entrustweb.md
@@ -28,7 +28,7 @@ description: 商户可以通过请求此接口唤起微信委托代扣的页面�
 ::: code-group
 
 ```php [标准PSR7]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Query;

--- a/openapi/v2/papay/h5entrustweb.md
+++ b/openapi/v2/papay/h5entrustweb.md
@@ -28,7 +28,7 @@ description: 该方式适用于手机、平板电脑等使用H5浏览器的设�
 ::: code-group
 
 ```php [异步纯链式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -69,7 +69,7 @@ $instance->v2->papay->h5entrustweb->getAsync([
 ```
 
 ```php [异步声明式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -110,7 +110,7 @@ $instance->chain('v2/papay/h5entrustweb')->getAsync([
 ```
 
 ```php [异步属性式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -151,7 +151,7 @@ $instance['v2/papay/h5entrustweb']->getAsync([
 ```
 
 ```php [同步纯链式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -189,7 +189,7 @@ print_r(\WeChatPay\Transformer::toArray((string) $response->getBody()));
 ```
 
 ```php [同步声明式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -227,7 +227,7 @@ print_r(\WeChatPay\Transformer::toArray((string) $response->getBody()));
 ```
 
 ```php [同步属性式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [

--- a/openapi/v2/papay/partner/entrustweb.md
+++ b/openapi/v2/papay/partner/entrustweb.md
@@ -29,7 +29,7 @@ description: 商户可以通过请求此接口唤起微信委托代扣的页面�
 ::: code-group
 
 ```php [标准PSR7]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Query;

--- a/openapi/v2/papay/partner/h5entrustweb.md
+++ b/openapi/v2/papay/partner/h5entrustweb.md
@@ -38,7 +38,7 @@ description: 该方式适用于手机、平板电脑等使用H5浏览器的设�
 ::: code-group
 
 ```php [异步纯链式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -81,7 +81,7 @@ $instance->v2->papay->partner->h5entrustweb->getAsync([
 ```
 
 ```php [异步声明式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -124,7 +124,7 @@ $instance->chain('v2/papay/partner/h5entrustweb')->getAsync([
 ```
 
 ```php [异步属性式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -167,7 +167,7 @@ $instance['v2/papay/partner/h5entrustweb']->getAsync([
 ```
 
 ```php [同步纯链式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -207,7 +207,7 @@ print_r(\WeChatPay\Transformer::toArray((string) $response->getBody()));
 ```
 
 ```php [同步声明式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [
@@ -247,7 +247,7 @@ print_r(\WeChatPay\Transformer::toArray((string) $response->getBody()));
 ```
 
 ```php [同步属性式]
-use WeChatPay\Hash;
+use WeChatPay\Crypto\Hash;
 use WeChatPay\Formatter;
 
 $params = [


### PR DESCRIPTION
I found a documentation error in the code example. The original code incorrectly uses use WeChatPay\Hash;, but the correct namespace should be use WeChatPay\Crypto\Hash;. This PR updates the documentation to reflect the correct namespace to avoid confusion for developers using the WeChatPay library.